### PR TITLE
MANTA-4992 Update electric-moray fast server to use node-fast 3.0.0 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,11 @@
+# electric-moray Changelog
+
+## 1.2.0
+
+- [#13](https://github.com/joyent/electric-moray/issues/13) MANTA-4992 Update
+  electric-moray fast server to use node-fast 3.0.0. Node-fast version 3.0.0
+  moves the fast protocol version to version 2. The fast client communications
+  with moray are handled by node-moray 3.7.0 and are not changed as part of this
+  release.  This means that this version of electric-moray can communicate with
+  moray servers using older versions of node-fast as well as moray servers that
+  are updated to use node-fast 3.0.0.

--- a/lib/moray_client.js
+++ b/lib/moray_client.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var assert = require('assert-plus');
@@ -25,7 +25,6 @@ function createClient(options, callback) {
     assert.object(options.log, 'options.log');
     assert.object(options.ring, 'options.ring');
     assert.object(options.morayOptions, 'options.morayOptions');
-    assert.number(options.crc_mode, 'options.crc_mode');
     assert.func(callback, 'options.callback');
 
     var log = options.log;
@@ -59,7 +58,15 @@ function createClient(options, callback) {
             morayargs.log = options.log.child({
                 component: 'moray-client-' + pnodeUrl.hostname
             });
-            morayargs.crc_mode = options.crc_mode;
+            /*
+             * This is to set to facilitate transitioning electric-moray and
+             * moray to node-fast 3.0.0. It accounts for moray servers that have
+             * have updated to node-fast 2.8.1 that introduced the crc_mode
+             * settings as a means to migrate off a buggy node-crc version. This
+             * will be removed in a subsequent release when the node-fast client
+             * for electric-moray is updated to node-fast 3.0.0.
+             */
+            morayargs.crc_mode = 1;
 
             var client = moray.createClient(morayargs);
             clientMap[pnode] = client;

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,7 @@
  */
 
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  */
 
 var assert = require('assert-plus');
@@ -118,10 +118,6 @@ function createServer(options, callback) {
     assert.func(callback, 'callback');
     assert.string(options.ringLocation, 'options.ringLocation');
     assert.optionalObject(options.fast, 'options.fast');
-    assert.optionalNumber(options.fast.client_crc_mode,
-        'options.fast.client_crc_mode');
-    assert.optionalNumber(options.fast.server_crc_mode,
-        'options.fast.server_crc_mode');
 
     var log = options.log;
     var opts = {
@@ -147,17 +143,11 @@ function createServer(options, callback) {
 
         opts.ring = _ring;
 
-        var client_crc_mode = options.fast.client_crc_mode ||
-            fast.FAST_CHECKSUM_V1;
-        var server_crc_mode = options.fast.server_crc_mode ||
-            fast.FAST_CHECKSUM_V1;
-
         log.info('creating moray clients');
         moray_client.createClient({
             ring: opts.ring,
             morayOptions: options.morayOptions,
-            log: options.log,
-            crc_mode: client_crc_mode
+            log: options.log
         }, function (cErr, clients) {
             if (cErr) {
                 throw new verror.VError(cErr, 'unable to create moray clients');
@@ -177,22 +167,11 @@ function createServer(options, callback) {
                 labels: labels
             });
 
-            collector.gauge({
-                name: 'fast_client_crc_mode',
-                help: 'The node-fast CRC compatibilty mode of the Fast client'
-            }).set(client_crc_mode);
-
-            collector.gauge({
-                name: 'fast_server_crc_mode',
-                help: 'The node-fast CRC compatibilty mode of the Fast server'
-            }).set(server_crc_mode);
-
             var socket = net.createServer({ 'allowHalfOpen': true });
             var server = new fast.FastServer({
                 collector: collector,
                 log: log.child({ component: 'fast' }),
-                server: socket,
-                crc_mode: server_crc_mode
+                server: socket
             });
 
             var methods = [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "clone": "0.1.9",
         "dtrace-provider": "0.2.8",
         "fash": "2.5.0",
-        "fast": "2.8.1",
+        "fast": "3.0.0",
         "jsprim": "2.0.0",
         "kang": "1.2.0",
         "ldapjs": "0.6.3",

--- a/sapi_manifests/electric-moray/template
+++ b/sapi_manifests/electric-moray/template
@@ -6,20 +6,6 @@
             "type": "udp"
         }
     },
-    "fast": {
-      {{#MORAY_FAST_CLIENT_CRC_MODE}}
-      "client_crc_mode": {{MORAY_FAST_CLIENT_CRC_MODE}},
-      {{/MORAY_FAST_CLIENT_CRC_MODE}}
-      {{^MORAY_FAST_CLIENT_CRC_MODE}}
-      "client_crc_mode": 1,
-      {{/MORAY_FAST_CLIENT_CRC_MODE}}
-      {{#MORAY_FAST_SERVER_CRC_MODE}}
-      "server_crc_mode": {{MORAY_FAST_SERVER_CRC_MODE}}
-      {{/MORAY_FAST_SERVER_CRC_MODE}}
-      {{^MORAY_FAST_SERVER_CRC_MODE}}
-      "server_crc_mode": 2
-      {{/MORAY_FAST_SERVER_CRC_MODE}}
-    },
     "numWorkers": 0,
     "audit": false,
     "cache": {


### PR DESCRIPTION
Backport MANTA-4992 changes to `mantav1` branch.